### PR TITLE
Pass kwargs to Blueprint loaded routes

### DIFF
--- a/flask_via/routers/default.py
+++ b/flask_via/routers/default.py
@@ -400,7 +400,7 @@ class Blueprint(BaseRouter, RoutesImporter):
         routes = self.include(self.routes_module, self.routes_name)
 
         # Load the routes
-        self.load(blueprint, routes)
+        self.load(blueprint, routes, **kwargs)
 
         # Register the blueprint with the application
         app.register_blueprint(blueprint)


### PR DESCRIPTION
Passing kwargs in with routes loaded via Blueprints so Resource routings would continue to work as those require restful_api argument to be passed.
