### PR TITLE
Fix setup.py requirements reading to enable bdist_wheel

### DIFF
--- a/REQS.TESTING.txt
+++ b/REQS.TESTING.txt
@@ -2,7 +2,7 @@
 # Test Requirements
 #
 
-pytest==2.5.2
+pytest==2.6.4
 pytest-cov==1.6
 pytest_spec==0.2.22
 

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,10 @@ def read_requirements(filename):
     requirements = []
     with open(filename) as f:
         for line in f.readlines():
+            line = line.strip()
             if not line or line.startswith('#'):
                 continue
-            requirements.append(line.strip())
+            requirements.append(line)
     return requirements
 
 # Get current working directory


### PR DESCRIPTION
Without this, `setup.py bdist_wheel` (and `pip wheel Flask-Via`) gives `ValueError: ('No requirements found', '')`
